### PR TITLE
[cli] Implement Sub Commands

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -29,7 +29,7 @@ func (c *Config) Load() error {
 	filePath := filepath.Join(homeDir, localConfig)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("error reading config file: %s", err)
+		return fmt.Errorf("error: no auth token, obtain at https://jprq.io/auth")
 	}
 	if err := json.Unmarshal(data, &c.Local); err != nil {
 		return fmt.Errorf("error unmarshaling config file contents: %s", err)

--- a/cli/main.go
+++ b/cli/main.go
@@ -2,32 +2,72 @@ package main
 
 import (
 	"fmt"
-	"github.com/azimjohn/jprq/server/events"
 	"log"
 	"net"
 	"os"
 	"os/signal"
+	"regexp"
+	"strconv"
 	"time"
 )
 
 var version = "2.0"
-var authUrl = "https://jprq.io/auth"
+
+func printHelp() {
+	fmt.Println("Usage: jprq <command> [arguments]\n")
+	fmt.Println("Commands:")
+	fmt.Println("  auth <token>               Set authentication token from jprq.io/auth")
+	fmt.Println("  tcp <port>                 Start a TCP tunnel on the specified port")
+	fmt.Println("  http <port>                Start an HTTP tunnel on the specified port")
+	fmt.Println("  http <port> -s <subdomain> Start an HTTP tunnel with a custom subdomain")
+	fmt.Println("  --help                     Show this help message")
+	fmt.Println("  --version                  Show the version number")
+	os.Exit(0)
+}
 
 func main() {
 	log.SetFlags(0)
+	if len(os.Args) < 2 {
+		log.Fatal("no command specified")
+	}
 
-	port := 3000
+	command := os.Args[1]
+	args := os.Args[2:]
+	protocol := ""
+
+	switch command {
+	case "auth":
+		handleAuth(args)
+	case "tcp", "http":
+		protocol = command
+	case "help", "--help":
+		printHelp()
+	case "version", "--version":
+		printVersion()
+	default:
+		log.Fatalf("unknown command: %s, jprq --help", command)
+	}
+
+	if len(args) < 1 {
+		log.Fatal("please specify port number, jprq --help")
+	}
+	port, err := strconv.Atoi(args[0])
+	if err != nil {
+		log.Fatalf("port number must be an integer")
+	}
 	subdomain := ""
-	protocol := events.HTTP
-
-	if !canReachServer(port) {
-		log.Fatalf("error: can't reach server on port: %d\n", port)
+	if len(args) == 3 && args[1] == "-s" {
+		subdomain = validate(args[2])
 	}
 
 	var conf Config
 	if err := conf.Load(); err != nil {
 		log.Fatal(err)
 	}
+	if !canReachServer(port) {
+		log.Fatalf("error: cannot reach server on port: %d\n", port)
+	}
+
 	client := jprqClient{
 		config:    conf,
 		protocol:  protocol,
@@ -41,6 +81,30 @@ func main() {
 	<-signalChan
 }
 
+func validate(subdomain string) string {
+	subdomainRegex := `^[a-z\d](?:[a-z\d]|-[a-z\d]){0,38}$`
+	if !regexp.MustCompile(subdomainRegex).MatchString(subdomain) {
+		log.Fatalf("error: subdomain must be lowercase & alphanumeric")
+	}
+	return subdomain
+}
+
+func handleAuth(args []string) {
+	if len(args) != 1 {
+		log.Fatalf("invalid command, jprq --help")
+	}
+	config := Config{
+		Local: struct {
+			AuthToken string `json:"auth_token"`
+		}{args[0]},
+	}
+	if err := config.Write(); err != nil {
+		log.Fatalf("error writing config: %s", err)
+	}
+	log.Println("auth token has been set")
+	os.Exit(0)
+}
+
 func canReachServer(port int) bool {
 	address := fmt.Sprintf("127.0.0.1:%d", port)
 	conn, err := net.DialTimeout("tcp", address, time.Second)
@@ -49,4 +113,9 @@ func canReachServer(port int) bool {
 	}
 	conn.Close()
 	return true
+}
+
+func printVersion() {
+	log.Printf("v%s", version)
+	os.Exit(0)
 }


### PR DESCRIPTION
```
Usage: jprq <command> [arguments]

Commands:
  auth <token>               Set authentication token from jprq.io/auth
  tcp <port>                 Start a TCP tunnel on the specified port
  http <port>                Start an HTTP tunnel on the specified port
  http <port> -s <subdomain> Start an HTTP tunnel with a custom subdomain
  --help                     Show this help message
  --version                  Show the version number
```