### PR TITLE
Ability to Block Users

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	TLSKeyFile          string
 	GithubClientID      string
 	GithubClientSecret  string
+	BlockedUsersFile    string
 }
 
 func (c *Config) Load() error {
@@ -29,6 +30,7 @@ func (c *Config) Load() error {
 	c.TLSCertFile = os.Getenv("JPRQ_TLS_CERT")
 	c.GithubClientID = os.Getenv("GITHUB_CLIENT_ID")
 	c.GithubClientSecret = os.Getenv("GITHUB_CLIENT_SECRET")
+	c.BlockedUsersFile = "/etc/jprq/blocked-users.csv"
 
 	if c.DomainName == "" {
 		return errors.New("jprq domain env is not set")

--- a/server/github/github.go
+++ b/server/github/github.go
@@ -11,6 +11,7 @@ import (
 const tokenPrefix = "gho_"
 
 type User struct {
+	ID    int    `json:"id"`
 	Name  string `json:"name"`
 	Login string `json:"login"`
 }
@@ -97,6 +98,6 @@ func (g github) Authenticate(token string) (User, error) {
 	if err != nil {
 		return user, fmt.Errorf("failed to decode user data: %v", err)
 	}
-
+	user.Login = strings.ToLower(user.Login)
 	return user, nil
 }

--- a/server/jprq.go
+++ b/server/jprq.go
@@ -111,7 +111,7 @@ func (j *Jprq) serveEventConn(conn net.Conn) error {
 		return events.WriteError(conn, "authentication failed")
 	}
 	if reason, found := j.blockedUsers[user.Login]; found {
-		return events.WriteError(conn, "account blocked for %s", reason)
+		return events.WriteError(conn, "your account is blocked for %s", reason)
 	}
 	if len(j.userTunnels[user.Login]) >= j.config.MaxTunnelsPerUser {
 		return events.WriteError(conn, "tunnels limit reached for %s", user.Login)
@@ -202,6 +202,8 @@ func (j *Jprq) loadBlockedUsers() {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+	j.blockedUsers = make(map[string]string)
+
 	for scanner.Scan() {
 		fields := strings.Split(scanner.Text(), ",")
 		if len(fields) >= 2 {
@@ -211,5 +213,5 @@ func (j *Jprq) loadBlockedUsers() {
 	}
 
 	j.blockedLastMod = stat.ModTime()
-	log.Println("blocked users list loaded")
+	log.Println("new blocked users list loaded")
 }

--- a/server/jprq.go
+++ b/server/jprq.go
@@ -161,7 +161,11 @@ func (j *Jprq) serveEventConn(conn net.Conn) error {
 	fmt.Printf("%s [tunnel-opened] %s: %s\n", time.Now().Format(dateFormat), user.Login, tunnelId)
 	buffer := make([]byte, 8) // wait until connection is closed
 	for {
+		_ = conn.SetReadDeadline(time.Now().Add(time.Minute))
 		if _, err := conn.Read(buffer); err == io.EOF {
+			break
+		}
+		if _, found := j.blockedUsers[user.Login]; found {
 			break
 		}
 	}


### PR DESCRIPTION
Some users may want to use jprq for malicious purposes.
Tunnels are monitored for phishing acitivies and such users are blocked.