### PR TITLE
XDG Base Directory Specification support

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -56,7 +56,7 @@ func (c *Config) Write() error {
 		return fmt.Errorf("error getting user config directory: %s", err)
 	}
 	dirPath := filepath.Join(configDir, "jprq")
-    if err := os.Mkdir(dirPath, 0700); err != nil && os.IsNotExist(err) {
+    if err := os.MkdirAll(dirPath, 0700); err != nil && os.IsNotExist(err) {
 		return fmt.Errorf("error creating config directory: %s", err)
     }
     filePath := filepath.Join(dirPath, localConfig)

--- a/cli/config.go
+++ b/cli/config.go
@@ -22,11 +22,11 @@ type Config struct {
 }
 
 func (c *Config) Load() error {
-	homeDir, err := os.UserHomeDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return fmt.Errorf("error getting user home directory: %s", err)
+		return fmt.Errorf("error getting user config directory: %s", err)
 	}
-	filePath := filepath.Join(homeDir, localConfig)
+	filePath := filepath.Join(configDir, "jprq", localConfig)
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("error: no auth token, obtain at https://jprq.io/auth")
@@ -51,11 +51,15 @@ func (c *Config) Write() error {
 	if err != nil {
 		return fmt.Errorf("error marshaling config: %s", err)
 	}
-	homeDir, err := os.UserHomeDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return fmt.Errorf("error getting user home directory: %s", err)
+		return fmt.Errorf("error getting user config directory: %s", err)
 	}
-	filePath := filepath.Join(homeDir, localConfig)
+	dirPath := filepath.Join(configDir, "jprq")
+    if err := os.Mkdir(dirPath, 0700); err != nil && os.IsNotExist(err) {
+		return fmt.Errorf("error creating config directory: %s", err)
+    }
+    filePath := filepath.Join(dirPath, localConfig)
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("error creating config file: %s", err)


### PR DESCRIPTION
Previously, the application stored its configuration files in the user's home directory. With this change, they are stored in the $XDG_CONFIG_HOME/jprq directory, as specified by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). This eliminates the need for the application to clutter the user's home directory with unnecessary config files. Furthermore, by adhering to the Specification's guidelines, this change allows the application to more easily manage related configuration files in a central location in the future.