### PR TITLE
Fix Debugger Cpu Load Issue

### DIFF
--- a/cli/jprqc.go
+++ b/cli/jprqc.go
@@ -110,6 +110,7 @@ func (j *jprqClient) handleEvent(event events.ConnectionReceived) {
 }
 
 func bind(src net.Conn, dst net.Conn, debugCon io.Writer) error {
+	defer src.Close()
 	defer dst.Close()
 	buf := make([]byte, 4096)
 	for {


### PR DESCRIPTION
Solves #135.

The issue was reproducible on my Linux machine as well. After running command with `--debug` option and accessing a public endpoint, CPU utilization increases instantly, in my case up to 220%. However, just closing source connection in bind function fixed the issue for me.

