### PR TITLE
Fix cli flags order

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -56,11 +56,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("port number must be an integer")
 	}
+
 	subdomain := ""
-	if len(args) > 3 && args[1] == "-s" {
+	var debug bool
+	if len(args) > 2 && args[1] == "-s" {
 		subdomain = validate(args[2])
+		debug = args[len(args)-1] == "--debug"
+	} else if len(args) > 2 && args[2] == "-s" {
+		subdomain = validate(args[3])
+		debug = args[1] == "--debug"
+	} else {
+		debug = args[len(args)-1] == "--debug"
 	}
-	debug := args[len(args)-1] == "--debug"
 
 	var conf Config
 	if err := conf.Load(); err != nil {


### PR DESCRIPTION
Fixes #148

After recent changes, there is a little confusion in the flags order. If a user has a flag `-s` for the subdomain feature, it doesn't work. However, it works when there is also a `--debug` option in the last parameter. This PR will temporarily fix that issue. I'd suggest using Go's [flag](https://pkg.go.dev/flag) package as more options may appear in the future.