### PR TITLE
free function which kills jprq processes using cmd

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -5,9 +5,12 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/exec"
 	"os/signal"
 	"regexp"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -21,9 +24,32 @@ func printHelp() {
 	fmt.Println("  http <port>                Start an HTTP tunnel on the specified port")
 	fmt.Println("  http <port> -s <subdomain> Start an HTTP tunnel with a custom subdomain")
 	fmt.Println("  http <port> --debug        Debug an HTTP tunnel with Jprq Debugger")
+	fmt.Println("  --free                     Free up the port when the client is running in the background")
 	fmt.Println("  --help                     Show this help message")
 	fmt.Println("  --version                  Show the version number")
 	os.Exit(0)
+}
+
+// freeClient function is called when jprq --free is called.
+// It kills the jprq processes running on the system.
+// It is called when the user wants to free up the port when the client is running in the background
+func freeClient() {
+	var cmd *exec.Cmd
+	// check the OS and run the appropriate command
+	if strings.Contains(runtime.GOOS, "windows") {
+		cmd = exec.Command("taskkill", "/IM", "jprq.exe", "/F")
+	} else if strings.Contains(runtime.GOOS, "darwin") || strings.Contains(runtime.GOOS, "linux") {
+		cmd = exec.Command("killall", "jprq")
+	} else {
+		log.Fatal("currently unsupported OS")
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		log.Println("error killing jprq process")
+		os.Exit(1)
+	}
+
 }
 
 func main() {
@@ -45,6 +71,8 @@ func main() {
 		printHelp()
 	case "version", "--version":
 		printVersion()
+	case "free", "--free": // jprq --free if called
+		freeClient()
 	default:
 		log.Fatalf("unknown command: %s, jprq --help", command)
 	}

--- a/server/jprq.go
+++ b/server/jprq.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -92,7 +91,7 @@ func (j *Jprq) servePublicConn(conn net.Conn) error {
 	t, found := j.httpTunnels[host]
 	if !found {
 		writeResponse(conn, 404, "Not Found", "tunnel not found. create one at jprq.io")
-		return errors.New(fmt.Sprintf("unknown host requested %s", host))
+		return fmt.Errorf("unknown host requested %s", host)
 	}
 	return t.PublicConnectionHandler(conn, buffer)
 }
@@ -128,7 +127,7 @@ func (j *Jprq) serveEventConn(conn net.Conn) error {
 	}
 	hostname := fmt.Sprintf("%s.%s", request.Subdomain, j.config.DomainName)
 	if _, ok := j.httpTunnels[hostname]; ok {
-		return events.WriteError(conn, "subdomain is busy: %s, try another one", request.Subdomain)
+		return events.WriteError(conn, "subdomain is busy: %s, try another one \n or free using 'jrpq --free'", request.Subdomain)
 	}
 
 	var t tunnel.Tunnel


### PR DESCRIPTION
To address the problem with the process running in background and user having no idea that client is not stopped I came up with idea that it is better give user handy function. So freeClient() function is called when --free arg is passed to kill all jprq processes . This is my temporary solution to [https://github.com/azimjohn/jprq/issues/157] issue. I have one more idea: stopping client when there is no traffic in particular range of time. If you liked this idea of stopping client with no traffic, I will be honored to work on. 