### PR TITLE
"$" removed from bash commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,26 +18,28 @@
 
 1. Install the latest <a href='https://github.com/azimjohn/jprq/releases'>release</a> of JPRQ<br>
 2. Place the file where it is convenient for you<br><br>
-<i>(At this point, you can use the program, but you will need to manually call the <code>.exe</code> file)</i><br>
+   <i>(At this point, you can use the program, but you will need to manually call the <code>.exe</code> file)</i><br>
 3. Create <b>jprq.bat</b> file so we can use the "jprq" keyword to call the <b>.exe</b> file<br>
-    
-    ```bash
-    @echo off
-    "C:\Exact\Path\To\File\jprq-windows-386.exe" %*
-    ```
+
+   ```bash
+   @echo off
+   "C:\Exact\Path\To\File\jprq-windows-386.exe" %*
+   ```
 
 4. Awesome! Finally, we need to <a href="https://www.youtube.com/watch?v=gb9e3m98avk">add to the environment variable "PATH"</a>, the path to the folder where we created .bat file <i>(step 3)</i><br><br>
 <p align='center'><b>Congratulations!</b> You can check if everything is working with the jprq command in CMD</p>
 <hr>
-    
+
+
 </details>
 
 <details>
     <summary> MacOs and Linux</summary>
 
 ```bash
-$ curl -fsSL https://jprq.io/install.sh | sudo bash
+curl -fsSL https://jprq.io/install.sh | sudo bash
 ```
+
 </details>
 
 ## How to use
@@ -45,27 +47,29 @@ $ curl -fsSL https://jprq.io/install.sh | sudo bash
 First obtain auth token from https://jprq.io/auth, then
 
 ```bash
-$ jprq auth <your-auth-token>
+jprq auth <your-auth-token>
 ```
 
 Replace 8000 with the port you want to expose
 
 ```bash
-$ jprq http 8000
+jprq http 8000
 ```
 
 For exposing any TCP servers, such as SSH
 
 ```bash
-$ jprq tcp 22
+jprq tcp 22
 ```
 
 For using custom subdomains
+
 ```bash
-$ jprq http 3000 -s custom
+jprq http 3000 -s custom
 ```
 
 For using jprq debugger (with v2.1 or higher)
+
 ```bash
 jprq http 3000 --debug
 ```


### PR DESCRIPTION
When copying bash commands "$" also comes with it and it forces to delete from each copy/paste.