### PR TITLE
"$" removed from bash commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@
     <summary> MacOs and Linux</summary>
 
 ```bash
-$ curl -fsSL https://jprq.io/install.sh | sudo bash
+curl -fsSL https://jprq.io/install.sh | sudo bash
 ```
 </details>
 
@@ -45,24 +45,24 @@ $ curl -fsSL https://jprq.io/install.sh | sudo bash
 First obtain auth token from https://jprq.io/auth, then
 
 ```bash
-$ jprq auth <your-auth-token>
+jprq auth <your-auth-token>
 ```
 
 Replace 8000 with the port you want to expose
 
 ```bash
-$ jprq http 8000
+jprq http 8000
 ```
 
 For exposing any TCP servers, such as SSH
 
 ```bash
-$ jprq tcp 22
+jprq tcp 22
 ```
 
 For using custom subdomains
 ```bash
-$ jprq http 3000 -s custom
+jprq http 3000 -s custom
 ```
 
 For using jprq debugger (with v2.1 or higher)


### PR DESCRIPTION
When copying bash commands "$" also comes with it and it forces to delete from each copy/paste.