### PR TITLE
Add Scoop installation method to Windows install instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,14 @@
 
 <details>
 <summary>Windows</summary>
+
+
+### Install via Scoop (Recommended)
+```bash
+scoop install jprq
+```
+
+### Manual Installation
 <p align='center'><a href="https://youtube.com/watch?v=frgVQPi-GlY">📹Video tutorial</a><br></p>
 
 1. Install the latest <a href='https://github.com/azimjohn/jprq/releases'>release</a> of JPRQ<br>


### PR DESCRIPTION
# 📦 Add Scoop Installation for JPRQ

## Description
This PR adds **Scoop** package support for **JPRQ**, allowing users to install it easily using:

```bash
scoop install jprq
```

## PR Description  

## 🔄 Changes  
- Updated installation instructions to include Scoop.  

## 🔗 Related PR & Discussions  
- [Scoop](https://scoop.sh/) repository PR: [#6597](https://github.com/ScoopInstaller/Main/pull/6597)  
- JPRQ discussion: [#101](https://github.com/azimjohn/jprq/discussions/101)