### PR TITLE
fix: panic on no arg for flag

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -107,8 +107,14 @@ func parseFlags(args []string) Flags {
 		case "-d", "-debug", "--debug":
 			flags.debug = true
 		case "-s", "-subdomain", "--subdomain":
+			if i+1 >= len(args) {
+				log.Fatal("missing value for subdomain flag, jprq --help")
+			}
 			flags.subdomain = args[i+1]
 		case "-c", "-cname", "--cname":
+			if i+1 >= len(args) {
+				log.Fatal("missing value for cname flag, jprq --help")
+			}
 			flags.cname = args[i+1]
 		}
 	}


### PR DESCRIPTION
## 📌 Summary

Addresses panic when no argument is given for certain flags, i.e., subdomain and cname.  

## 🔍 Related Issues

Closes #260 

## 📚 Notes

- Need clarification on what's wrong with short subdomain error format

## ✅ Checklist

- [x] Code compiles correctly
- [ ] Tests added or updated
