### PR TITLE
modify authHandler to check for app queries

### DIFF
--- a/website/main.go
+++ b/website/main.go
@@ -99,11 +99,11 @@ func oauthCallback(w http.ResponseWriter, r *http.Request) {
 		var appURL string
 		switch appCookie.Value {
 		case "mac":
-			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+			appURL = fmt.Sprintf("jprq://auth/callback?token=%s", token)
 		case "windows":
-			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+			appURL = fmt.Sprintf("jprq://auth/callback?token=%s", token)
 		case "linux":
-			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+			appURL = fmt.Sprintf("jprq://auth/callback?token=%s", token)
 		default:
 			// Unknown app type, fall back to web display
 			w.Header().Set("Content-Type", "text/html")

--- a/website/main.go
+++ b/website/main.go
@@ -50,7 +50,25 @@ func contentHandler(content []byte, contentType string) func(w http.ResponseWrit
 }
 
 func authHandler(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, oauth.OAuthUrl(), http.StatusFound)
+	// Pass the app parameter to the OAuth state if present
+	app := r.URL.Query().Get("app")
+	oauthURL := oauth.OAuthUrl()
+
+	// If app parameter is present, add it to the state
+	if app != "" {
+		// Store app parameter in session or pass it through state
+		// For now, we'll use a cookie to preserve it
+		http.SetCookie(w, &http.Cookie{
+			Name:     "jprq_app",
+			Value:    app,
+			Path:     "/",
+			MaxAge:   300, // 5 minutes
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
+	http.Redirect(w, r, oauthURL, http.StatusFound)
 }
 
 func oauthCallback(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +82,40 @@ func oauthCallback(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth", http.StatusTemporaryRedirect)
 		return
 	}
+
+	// Check if this is an app-based authentication
+	appCookie, err := r.Cookie("jprq_app")
+	if err == nil && appCookie.Value != "" {
+		// Clear the cookie
+		http.SetCookie(w, &http.Cookie{
+			Name:     "jprq_app",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+		})
+
+		// Redirect to the app URL with the token
+		var appURL string
+		switch appCookie.Value {
+		case "mac":
+			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+		case "windows":
+			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+		case "linux":
+			appURL = fmt.Sprintf("jprq://auth?token=%s", token)
+		default:
+			// Unknown app type, fall back to web display
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(fmt.Sprintf(tokenHtml, token)))
+			return
+		}
+
+		http.Redirect(w, r, appURL, http.StatusFound)
+		return
+	}
+
+	// Default: show token in web page
 	w.Header().Set("Content-Type", "text/html")
 	w.Write([]byte(fmt.Sprintf(tokenHtml, token)))
 }


### PR DESCRIPTION
Added app-based authentication flow to allow desktop apps to receive auth tokens via deep links
Uses cookies to preserve app type through OAuth flow, then redirects to `jprq://auth?token=...`